### PR TITLE
Added actions and rule to be able to save data into datastore via HTTP API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+### Python ###
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
+
+### Vim ###
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+### temporary files or auto generated files ###
+virtualenv
+tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+## 0.2.0
+
+Added these Actions
+
+* set_st2kv : Register specified key-value pair into datastore.
+* get_st2kv : Retrieve value from datastore which is correspond to specified key.
+
+Added a Rule
+
+* save_data_into_datastore : Create a webhook API to be able to save uploaded data into datastore.
+
+## 0.1.0
+
+- Initial release

--- a/actions/get_st2kv.py
+++ b/actions/get_st2kv.py
@@ -1,0 +1,14 @@
+import os
+
+from st2client.client import Client
+from st2common.runners.base_action import Action
+
+
+class GetKV(Action):
+    def run(self, key, **kwargs):
+        client = Client(api_url=os.environ['ST2_API_URL'])
+
+        # Retrieve value from datastore
+        kv_pair = client.keys.get_by_id(key, params=kwargs)
+
+        return (True, kv_pair.serialize())

--- a/actions/get_st2kv.yaml
+++ b/actions/get_st2kv.yaml
@@ -1,0 +1,15 @@
+---
+name: get-st2kv
+description: Get a key-value pair which is stored in the datastore of ST2
+runner_type: python-script
+entry_point: get_st2kv.py
+enabled: true
+parameters:
+  key:
+    type: string
+    required: true
+    description: key name to set
+  decrypt:
+    type: boolean
+    default: False
+    description: decrypt stored value when it's true

--- a/actions/set_st2kv.py
+++ b/actions/set_st2kv.py
@@ -1,0 +1,15 @@
+import os
+
+from st2client.client import Client
+from st2client.models import KeyValuePair
+from st2common.runners.base_action import Action
+
+
+class SetKV(Action):
+    def run(self, key, value, **kwargs):
+        client = Client(api_url=os.environ['ST2_API_URL'])
+
+        # Store value to datastore
+        kv_pair = client.keys.update(KeyValuePair(name=key, value=value, **kwargs))
+
+        return (True, kv_pair.serialize())

--- a/actions/set_st2kv.yaml
+++ b/actions/set_st2kv.yaml
@@ -1,0 +1,23 @@
+---
+name: set-st2kv
+description: Set key-value pair to the datastore of ST2
+runner_type: python-script
+entry_point: set_st2kv.py
+enabled: true
+parameters:
+  key:
+    type: string
+    required: true
+    description: key name to set
+  value:
+    type: string
+    required: true
+    description: value corresponding to key
+  ttl:
+    type: integer
+    default: 0
+    description: TTL (seconds) of setting value
+  secret:
+    type: boolean
+    default: False
+    description: whether storing value would be encrypted, or not

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ name: data_storage
 description: Automation pack to store freely-selected typed data in datastore and retrieve it
 keywords:
   - data store
-version: 0.1.0
+version: 0.2.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com

--- a/rules/save_data_into_datastore.yaml
+++ b/rules/save_data_into_datastore.yaml
@@ -1,0 +1,16 @@
+---
+name: save_data_into_datastore
+pack: data_storage
+description: Create a webhook API to be able to save uploaded data into datastore
+enabled: true
+
+trigger:
+    type: core.st2.webhook
+    parameters:
+        url: save_data_into_datastore
+
+action:
+    ref: data_storage.set-st2kv
+    parameters:
+        key: "{{ trigger.body.key }}"
+        value: "{{ trigger.body.data }}"

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,14 @@
+import os
+
+from st2tests.base import BaseActionTestCase
+
+
+class StorageBaseTestCase(BaseActionTestCase):
+    def setUp(self):
+        super(StorageBaseTestCase, self).setUp()
+
+        # clear property values which might be set at any tests
+        self.kv_pair = None
+
+        # set environment variables which is set in a StackStorm node by default
+        os.environ['ST2_API_URL'] = 'http://localhost/api/v1'

--- a/tests/test_get_st2kv.py
+++ b/tests/test_get_st2kv.py
@@ -1,0 +1,26 @@
+import mock
+
+from base import StorageBaseTestCase
+from get_st2kv import GetKV
+
+
+class GetKVTest(StorageBaseTestCase):
+    __test__ = True
+    action_cls = GetKV
+
+    @mock.patch('get_st2kv.Client')
+    def test_run_action(self, mock_client):
+        # Preparing for mock processing to check that action calls expected methods correctly
+        mock_resp = mock.Mock()
+        mock_resp.serialize.return_value = 'hogefuga'
+
+        mock_client_object = mock.Mock()
+        mock_client_object.keys.get_by_id.return_value = mock_resp
+        mock_client.return_value = mock_client_object
+
+        # Making an action and run it
+        (is_success, resp_data) = self.get_action_instance().run(key='key')
+
+        # This checks that action calls expected method
+        self.assertTrue(is_success)
+        self.assertEqual(resp_data, 'hogefuga')

--- a/tests/test_set_st2kv.py
+++ b/tests/test_set_st2kv.py
@@ -1,0 +1,38 @@
+import mock
+
+from base import StorageBaseTestCase
+from set_st2kv import SetKV
+from st2client.models import KeyValuePair
+
+
+class SetKVTest(StorageBaseTestCase):
+    __test__ = True
+    action_cls = SetKV
+
+    @mock.patch('set_st2kv.Client')
+    def test_run_action(self, mock_client):
+        def side_effect(kv_pair):
+            mock_resp = mock.Mock()
+            mock_resp.serialize.return_value = 'hogefuga'
+
+            # store specified value to check
+            self.kv_pair = kv_pair
+
+            return mock_resp
+
+        mock_client_object = mock.Mock()
+        mock_client_object.keys.update.side_effect = side_effect
+        mock_client.return_value = mock_client_object
+
+        # Making an action and run it
+        (is_success, resp_data) = self.get_action_instance().run(key='key', value='value', ttl=10)
+
+        # This checks that action calls expected method
+        self.assertTrue(is_success)
+        self.assertEqual(resp_data, 'hogefuga')
+
+        # This checks that action makes KeyValuePiar object with expected parameters
+        self.assertIsInstance(self.kv_pair, KeyValuePair)
+        self.assertEqual(self.kv_pair.name, 'key')
+        self.assertEqual(self.kv_pair.value, 'value')
+        self.assertEqual(self.kv_pair.ttl, 10)


### PR DESCRIPTION
## Abstract

This added these Actions.

* set_st2kv : Register specified key-value pair into datastore.
* get_st2kv : Retrieve value from datastore which is correspond to specified key.

And also added a Rule as below.

* save_data_into_datastore : Create a webhook API to be able to save uploaded data into datastore.

## Example of using
<img width="754" alt="スクリーンショット 2019-07-30 15 32 23" src="https://user-images.githubusercontent.com/469934/62106143-6694f500-b2df-11e9-87fc-3a9994f9513e.png">

(c.f. [more detail](https://gist.github.com/userlocalhost/e8ad08ee6e86f15c4f15852fc3d993aa))