### PR TITLE
Added action and workflow to post image which is stored in the datastore to Slack

### DIFF
--- a/actions/show_image_to_slack.yaml
+++ b/actions/show_image_to_slack.yaml
@@ -1,0 +1,22 @@
+---
+name: show_image_to_slack
+pack: data_storage
+description: Upload image data which is stored in the datastore to Slack
+runner_type: orquesta
+entry_point: workflows/show_image_to_slack.yaml
+enabled: true
+parameters:
+  key:
+    type: string
+    required: true
+    description: Key name of datastore which is corresponding to uploading data
+  channel:
+    type: string
+    description: The place where image will be posted
+    required: true
+  title:
+    type: string
+    description: Description of uploaded flie
+  text:
+    type: string
+    description: Text with uploaded file

--- a/actions/upload_data_to_slack.py
+++ b/actions/upload_data_to_slack.py
@@ -1,0 +1,57 @@
+import base64
+import os
+import random
+import string
+import requests
+
+from st2common.runners.base_action import Action
+
+
+class UploadDataToSlack(Action):
+    CONFIG_KEY_SLACK_TOKEN = 'slack_token'
+    SLACK_API_ENDPOINT_URL = 'https://slack.com/api/files.upload'
+
+    def run(self, data, channel, token=None, title='', text='', file_extension='.png'):
+        # Get an acess token of Slack from configuration when it's not specified in parameter
+        if not token and self.CONFIG_KEY_SLACK_TOKEN in self.config:
+            token = self.config[self.CONFIG_KEY_SLACK_TOKEN]
+
+        if not token:
+            return (False, 'Failed to get slack access token')
+
+        # call Slack API to upload file to the specified Slack channel
+        with TemporaryFile(data, file_extension) as filepath:
+            with open(filepath, 'rb') as fp:
+                resp = requests.post(url=self.SLACK_API_ENDPOINT_URL, params={
+                    'token': token,
+                    'channels': channel,
+                    'title': title,
+                    'initial_comment': text,
+                }, files={'file': fp})
+
+        if 200 <= resp.status_code <= 299:
+            return (True, resp.json())
+        else:
+            return (False, resp.content)
+
+
+class TemporaryFile(object):
+    SAVING_DIRECTORY = '/tmp'
+
+    def __init__(self, data, file_extension):
+        # generate filepath which is named randomly
+        self.filepath = (
+            '%s/%s%s' % (self.SAVING_DIRECTORY,
+                         ''.join(random.choice(string.ascii_lowercase) for _ in range(10)),
+                         file_extension))
+        self.data = data
+
+    def __enter__(self):
+        with open(self.filepath, 'wb') as fp:
+            fp.write(base64.b64decode(self.data))
+
+        return self.filepath
+
+    def __exit__(self, *args, **kwargs):
+        # close and remove a generated file
+        os.remove(self.filepath)

--- a/actions/upload_data_to_slack.yaml
+++ b/actions/upload_data_to_slack.yaml
@@ -1,0 +1,31 @@
+---
+name: upload_data_to_slack
+pack: data_storage
+description: Upload specified data to Slack
+runner_type: python-script
+entry_point: upload_data_to_slack.py
+enabled: true
+parameters:
+  data:
+    type: string
+    required: true
+    description: Data context which is encoded by base64
+  channel:
+    type: string
+    description: The place where image will be posted
+    required: true
+  token:
+    type: string
+    default: "{% if st2kv.user.slack_token|string %}{{ st2kv.user.slack_token|decrypt_kv }}{% endif %}"
+    description: User token of Slack
+    secret: true
+  title:
+    type: string
+    description: Description of uploaded flie
+  text:
+    type: string
+    description: Text with uploaded file
+  file_extension:
+    type: string
+    description: Upload file extension to notify file-type to Slack
+    default: '.png'

--- a/actions/workflows/show_image_to_slack.yaml
+++ b/actions/workflows/show_image_to_slack.yaml
@@ -1,0 +1,28 @@
+version: 1.0
+description: Upload image data which is stored in the datastore to Slack
+input:
+  - key
+  - channel
+  - title
+  - text
+
+tasks:
+  check_existence:
+    action: st2.kv.get
+    input:
+      key: <% ctx(key) %>
+    next:
+      - when: <% succeeded() %>
+        do: upload_image
+
+  upload_image:
+    action: data_storage.upload_data_to_slack
+    input:
+      data: "<% task(check_existence).result.result %>"
+      channel: "<% ctx(channel) %>"
+      title: "<% ctx(title) %>"
+      text: "<% ctx(text) %>"
+      file_extension: '.png'
+
+output:
+  - result: <% task(upload_image).result.result %>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/rules/save_data_into_datastore.yaml
+++ b/rules/save_data_into_datastore.yaml
@@ -10,7 +10,7 @@ trigger:
         url: save_data_into_datastore
 
 action:
-    ref: data_storage.set-st2kv
+    ref: st2.kv.set
     parameters:
         key: "{{ trigger.body.key }}"
         value: "{{ trigger.body.data }}"

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from st2tests.base import BaseActionTestCase
@@ -12,3 +13,12 @@ class StorageBaseTestCase(BaseActionTestCase):
 
         # set environment variables which is set in a StackStorm node by default
         os.environ['ST2_API_URL'] = 'http://localhost/api/v1'
+
+
+class FakeResponse(object):
+    def __init__(self, content, status_code):
+        self.content = content
+        self.status_code = status_code
+
+    def json(self):
+        return json.loads(self.content)

--- a/tests/test_upload_data_to_slack.py
+++ b/tests/test_upload_data_to_slack.py
@@ -1,0 +1,57 @@
+import base64
+import json
+import mock
+import os
+
+from base import StorageBaseTestCase
+from base import FakeResponse
+from upload_data_to_slack import UploadDataToSlack
+from upload_data_to_slack import TemporaryFile
+
+
+class UploadDataToSlackTest(StorageBaseTestCase):
+    __test__ = True
+    action_cls = UploadDataToSlack
+
+    @mock.patch('upload_data_to_slack.requests.post')
+    def test_post_image_to_slack(self, mock_post):
+        mock_post.return_value = FakeResponse(json.dumps({'ok': True}), 200)
+
+        (is_success, resp_data) = self.get_action_instance().run(**{
+            'data': 'hogefuga',
+            'channel': '#general',
+            'token': 'test-token',
+        })
+        self.assertTrue(is_success)
+        self.assertTrue(resp_data['ok'])
+
+    @mock.patch('upload_data_to_slack.requests.post')
+    def test_post_image_to_slack_with_failure(self, mock_post):
+        mock_post.return_value = FakeResponse('Some messages', 400)
+
+        (is_success, resp_data) = self.get_action_instance().run(**{
+            'data': 'hogefuga',
+            'channel': '#general',
+            'token': 'test-token',
+        })
+        self.assertFalse(is_success)
+        self.assertEqual(resp_data, 'Some messages')
+
+    def test_post_image_to_slack_without_token(self):
+        (is_success, resp_data) = self.get_action_instance().run(**{
+            'data': 'hogefuga',
+            'channel': '#general',
+        })
+        self.assertFalse(is_success)
+        self.assertEqual(resp_data, 'Failed to get slack access token')
+
+    def test_temprary_file(self):
+        data = base64.b64encode('hogefuga')
+
+        with TemporaryFile(data, '.txt') as filepath:
+            self.assertTrue(os.path.exists(filepath))
+            self.assertEqual(filepath[-4:], '.txt')
+            self.assertEqual(open(filepath, 'r').read(), 'hogefuga')
+
+        # This confirms that file of filepath would be deleted outside of with statement
+        self.assertFalse(os.path.exists(filepath))


### PR DESCRIPTION
## Abstract
This adds these action and workflow.

* (Action) upload_data_to_slack : Upload specified data to Slack
* (Workflow) show_image_to_slack : Upload image data which is stored in the datastore to Slack

## Example of using
When image data is stored in the datastore like this,
<img width="443" alt="スクリーンショット 2019-08-02 19 11 26" src="https://user-images.githubusercontent.com/469934/62363080-6142df00-b559-11e9-9900-6df2f0dca6d6.png">

You could post it to Slack by running `show_image_to_slack` workflow as below.
<img width="802" alt="スクリーンショット 2019-08-02 19 15 42" src="https://user-images.githubusercontent.com/469934/62363389-30af7500-b55a-11e9-8a98-e443c1b4d004.png">

Then, you could see new post with an image which is stored in datastore on the Slack.
<img width="373" alt="スクリーンショット 2019-08-02 19 16 14" src="https://user-images.githubusercontent.com/469934/62363462-5d638c80-b55a-11e9-9cd5-0d1f99515e4a.png">